### PR TITLE
feat: add support for multiple neovim instances

### DIFF
--- a/lua/bookmarks.lua
+++ b/lua/bookmarks.lua
@@ -67,6 +67,7 @@ M.setup = void(function(cfg)
    config.build(cfg)
    actions.setup()
    nvim.augroup "bookmarks"
+   autocmd("FocusGained", actions.loadBookmarks)
    autocmd("VimLeavePre", M.detach_all)
    autocmd("ColorScheme", hl.setup_highlights)
    on_or_after_vimenter(function()

--- a/lua/bookmarks/actions.lua
+++ b/lua/bookmarks/actions.lua
@@ -45,6 +45,7 @@ local function updateBookmarks(bufnr, lnum, mark, ann)
       -- M.saveBookmarks()
    end
    data[filepath] = marks
+   M.saveBookmarks()
 end
 
 M.toggle_signs = function(value)


### PR DESCRIPTION
I'm often using multiple instances of neovim in parallel.

Currently, when I add bookmarks in one instance, they won't be available until I close the instance in which they were added and open a new one. 
Furthermore, if another instance writes to `shada` or a bookmark is also added there it might mess up the available bookmarks.

This PR adds saving of bookmarks after updating them. Bookmarks get loaded when an nvim instance gains focus. So if a bookmark is added in one instance it is directly available via the telescope extension when moving to another instance.

Alternatively to not have this added as native behavior and leave it to the user: 
E.g. the local `updateBookmarks` function could emit an event. And users could use it achieve this functionality creating the necessary autocommands themselves. If there already is a way to hook into the update or a similar event please let me know.

Edit:
I'm just realizing it's is easily achievable via what the plugin provides already.
```lua
on_attach = function(bufnr)
	local actions = require("bookmarks.actions")
	nx.map({
		{
			"<leader>mm",
			function()
				bm.bookmark_toggle()
				actions.saveBookmarks()
			end,
			desc = "Bookmark toggle",
		},
		{
			"<leader>ma",
			function()
				bm.bookmark_ann()
				actions.saveBookmarks()
			end,
			desc = "Annotate",
		},
		-- ...
	})
	-- Sync marks between instances
	nx.au({ "FocusGained", callback = actions.loadBookmarks })
end

```

Or add the load action prior to opening telescope.

I think doing it this way gives most freedom to the users who doesn't want this functionality so I'm closing the PR. 
