### PR TITLE
feat: use annotation sign from config in telescope extensions

### DIFF
--- a/lua/telescope/_extensions/bookmarks.lua
+++ b/lua/telescope/_extensions/bookmarks.lua
@@ -14,7 +14,7 @@ local function get_text(annotation)
    local pref = string.sub(annotation, 1, 2)
    local ret = config.keywords[pref]
    if ret == nil then
-      ret = "♠ "
+      ret = config.signs.ann.text .. " "
    end
    return ret .. annotation
 end


### PR DESCRIPTION
With this PR the telescope extension will use the annotation signs from a users config instead of a hard-coded spades symbol when there is no keyword sign.


![Screenshot_20230701_192602](https://github.com/tomasky/bookmarks.nvim/assets/34311583/959e728f-4671-4496-b932-362c6721cf6a)

![Screenshot_20230701_192113](https://github.com/tomasky/bookmarks.nvim/assets/34311583/236f6a39-ce5c-4fb2-a77f-1811f5ff9c05)

