### PR TITLE
Don't create/do remove bookmarks file when there are no bookmarks.

### DIFF
--- a/lua/bookmarks/actions.lua
+++ b/lua/bookmarks/actions.lua
@@ -203,6 +203,11 @@ function M.loadBookmarks()
 end
 
 function M.saveBookmarks()
+   if utils.count_bookmarks(config.cache.data) == 0 then
+     utils.delete_file(config.save_file)
+    return
+   end
+
    local data = vim.json.encode(config.cache)
    if config.marks ~= data then
       utils.write_file(config.save_file, data)

--- a/lua/bookmarks/util.lua
+++ b/lua/bookmarks/util.lua
@@ -118,6 +118,30 @@ M.read_file = function(path, callback)
    end)
 end
 
+M.delete_file = function(path)
+   if M.path_exists(path) then
+      uv.fs_unlink(path, function(err)
+         assert(not err, err)
+      end)
+   end
+end
+
+local function count_keys(t)
+   local count = 0
+   for _ in pairs(t) do
+      count = count + 1
+   end
+   return count
+end
+
+M.count_bookmarks = function(cache)
+  local result = 0
+  for _, bookmarks in pairs(cache) do
+    result = result + count_keys(bookmarks)
+  end
+  return result
+end
+
 function M.warn(...)
    vim.notify(string.format(...), vim.log.levels.WARN)
 end


### PR DESCRIPTION
First of all, thank you for the plugin, it's great.

This change is motivated by the fact that once the bookmarks file is created it always remains there even if there are no bookmarks.
In my use case, I set up the plugin and set the save_file to point to the project's directory, so each project contains its own bookmarks.
This leaves a lot of bookmark files everywhere.

This change checks if there are bookmarks available, and if not it doesn't create the file. If there used to be bookmarks, but there are
none now, it deletes the bookmarks file to clean up.