### PR TITLE
feat: improve bookmark tracking with auto-refresh and line number adjustments

### DIFF
--- a/lua/bookmarks.lua
+++ b/lua/bookmarks.lua
@@ -11,74 +11,75 @@ local actions = require "bookmarks.actions"
 local M = {}
 
 local function wrap_func(fn, ...)
-   local args = { ... }
-   local nargs = select("#", ...)
-   return function()
-      fn(unpack(args, 1, nargs))
-   end
+  local args = { ... }
+  local nargs = select("#", ...)
+  return function()
+    fn(unpack(args, 1, nargs))
+  end
 end
 local function autocmd(event, opts)
-   local opts0 = {}
-   if type(opts) == "function" then
-      opts0.callback = wrap_func(opts)
-   else
-      opts0 = opts
-   end
-   opts0.group = "bookmarks"
-   nvim.autocmd(event, opts0)
+  local opts0 = {}
+  if type(opts) == "function" then
+    opts0.callback = wrap_func(opts)
+  else
+    opts0 = opts
+  end
+  opts0.group = "bookmarks"
+  nvim.autocmd(event, opts0)
 end
 
 local function on_detach(_, bufnr)
-   M.detach(bufnr, true)
+  M.detach(bufnr, true)
 end
 
 M.attach = void(function(bufnr)
-   bufnr = bufnr or current_buf()
-   scheduler()
-   actions.loadBookmarks()
-   if config.config.on_attach then
-      config.config.on_attach(bufnr)
-   end
-   if not api.nvim_buf_is_loaded(bufnr) then return end
-   api.nvim_buf_attach(bufnr, false, {
-      on_detach = on_detach,
-   })
+  bufnr = bufnr or current_buf()
+  scheduler()
+  actions.loadBookmarks()
+  if config.config.on_attach then
+    config.config.on_attach(bufnr)
+  end
+  if not api.nvim_buf_is_loaded(bufnr) then return end
+  api.nvim_buf_attach(bufnr, false, {
+    on_detach = on_detach,
+  })
 end)
 
 M.detach_all = void(function(bufnr)
-   bufnr = bufnr or current_buf()
-   scheduler()
-   actions.detach(bufnr)
-   actions.saveBookmarks()
+  bufnr = bufnr or current_buf()
+  scheduler()
+  actions.detach(bufnr)
+  actions.saveBookmarks()
 end)
 
 local function on_or_after_vimenter(fn)
-   if vim.v.vim_did_enter == 1 then
-      fn()
-   else
-      nvim.autocmd("VimEnter", {
-         callback = wrap_func(fn),
-         once = true,
-      })
-   end
+  if vim.v.vim_did_enter == 1 then
+    fn()
+  else
+    nvim.autocmd("VimEnter", {
+      callback = wrap_func(fn),
+      once = true,
+    })
+  end
 end
 
 M.setup = void(function(cfg)
-   config.build(cfg)
-   actions.setup()
-   nvim.augroup "bookmarks"
-   autocmd("VimLeavePre", M.detach_all)
-   autocmd("ColorScheme", hl.setup_highlights)
-   on_or_after_vimenter(function()
-      hl.setup_highlights()
-      M.attach()
-      autocmd("FocusGained", actions.refresh)
-      autocmd("BufReadPost", actions.refresh)
-   end)
+  config.build(cfg)
+  actions.setup()
+  nvim.augroup "bookmarks"
+  autocmd("VimLeavePre", M.detach_all)
+  autocmd("ColorScheme", hl.setup_highlights)
+  on_or_after_vimenter(function()
+    hl.setup_highlights()
+    M.attach()
+    autocmd("FocusGained", actions.refresh)
+    autocmd("BufReadPost", actions.refresh)
+    autocmd({ "TextChanged", "TextChangedI" }, actions.refresh)
+  end)
 end)
 
 return setmetatable(M, {
-   __index = function(_, f)
-      return actions[f]
-   end,
+  __index = function(_, f)
+    return actions[f]
+  end,
 })

--- a/lua/bookmarks/actions.lua
+++ b/lua/bookmarks/actions.lua
@@ -7,211 +7,246 @@ local api = vim.api
 local current_buf = api.nvim_get_current_buf
 local M = {}
 local signs
+local attached_buffers = {}
+
 M.setup = function()
-   signs = Signs.new(config.signs)
+  signs = Signs.new(config.signs)
 end
 
 M.detach = function(bufnr, keep_signs)
-   if not keep_signs then
-      signs:remove(bufnr)
-   end
+  if not keep_signs then
+    signs:remove(bufnr)
+  end
 end
 
 local function updateBookmarks(bufnr, lnum, mark, ann)
-   local filepath = uv.fs_realpath(api.nvim_buf_get_name(bufnr))
-   if filepath == nil then
-      return
-   end
-   local data = config.cache["data"]
-   local marks = data[filepath]
-   local isIns = false
-   if lnum == -1 then
-      marks = nil
+  local filepath = uv.fs_realpath(api.nvim_buf_get_name(bufnr))
+  if filepath == nil then
+    return
+  end
+  local data = config.cache["data"]
+  local marks = data[filepath]
+  local isIns = false
+  if lnum == -1 then
+    marks = nil
+    isIns = true
+  end
+  local line_count = api.nvim_buf_line_count(bufnr)
+  for k, _ in pairs(marks or {}) do
+    if k == tostring(lnum) then
       isIns = true
-      -- check buffer auto_save to file
-   end
-   local line_count = api.nvim_buf_line_count(bufnr)
-   for k, _ in pairs(marks or {}) do
-      if k == tostring(lnum) then
-         isIns = true
-         if mark == "" then
-            marks[k] = nil
-         end
-         break
-      elseif tonumber(k) > line_count then
-         marks[k] = nil
+      if mark == "" then
+        marks[k] = nil
       end
-   end
-   if isIns == false or ann then
-      marks = marks or {}
-      marks[tostring(lnum)] = ann and { m = mark, a = ann } or { m = mark }
-      -- check buffer auto_save to file
-      -- M.saveBookmarks()
-   end
-   data[filepath] = marks
+      break
+    elseif tonumber(k) > line_count then
+      marks[k] = nil
+    end
+  end
+  if isIns == false or ann then
+    marks = marks or {}
+    marks[tostring(lnum)] = ann and { m = mark, a = ann } or { m = mark }
+  end
+  data[filepath] = marks
 end
 
 M.toggle_signs = function(value)
-   if value ~= nil then
-      config.signcolumn = value
-   else
-      config.signcolumn = not config.signcolumn
-   end
-   M.refresh()
-   return config.signcolumn
+  if value ~= nil then
+    config.signcolumn = value
+  else
+    config.signcolumn = not config.signcolumn
+  end
+  M.refresh()
+  return config.signcolumn
 end
 
 M.bookmark_toggle = function()
-   local lnum = api.nvim_win_get_cursor(0)[1]
-   local bufnr = current_buf()
-   local signlines = { {
-      type = "add",
-      lnum = lnum,
-   } }
-   local isExt = signs:add(bufnr, signlines)
-   if isExt then
-      signs:remove(bufnr, lnum)
-      updateBookmarks(bufnr, lnum, "")
-   else
-      local line = api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, false)[1]
-      updateBookmarks(bufnr, lnum, line)
-   end
+  local lnum = api.nvim_win_get_cursor(0)[1]
+  local bufnr = current_buf()
+  local signlines = { {
+    type = "add",
+    lnum = lnum,
+  } }
+  local isExt = signs:add(bufnr, signlines)
+  if isExt then
+    signs:remove(bufnr, lnum)
+    updateBookmarks(bufnr, lnum, "")
+  else
+    local line = api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, false)[1]
+    updateBookmarks(bufnr, lnum, line)
+  end
 end
 
 M.bookmark_clean = function()
-   local bufnr = current_buf()
-   signs:remove(bufnr)
-   updateBookmarks(bufnr, -1, "")
+  local bufnr = current_buf()
+  signs:remove(bufnr)
+  updateBookmarks(bufnr, -1, "")
 end
 
 M.bookmark_line = function(lnum, bufnr)
-   bufnr = bufnr or current_buf()
-   local file = uv.fs_realpath(api.nvim_buf_get_name(bufnr))
-   local marks = config.cache["data"][file] or {}
-   return lnum and marks[tostring(lnum)] or marks
+  bufnr = bufnr or current_buf()
+  local file = uv.fs_realpath(api.nvim_buf_get_name(bufnr))
+  local marks = config.cache["data"][file] or {}
+  return lnum and marks[tostring(lnum)] or marks
 end
 
 M.bookmark_ann = function()
-   local lnum = api.nvim_win_get_cursor(0)[1]
-   local bufnr = current_buf()
-   local signlines = { {
-      type = "ann",
-      lnum = lnum,
-   } }
-   local mark = M.bookmark_line(lnum, bufnr)
-   vim.ui.input({ prompt = "Edit:", default = mark.a }, function(answer)
-      if answer == nil then return end
-      local line = api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, false)[1]
-      signs:remove(bufnr, lnum)
-      local text = config.keywords[string.sub(answer or "", 1, 2)]
-      if text then
-         signlines[1]["text"] = text
-      end
-      signs:add(bufnr, signlines)
-      updateBookmarks(bufnr, lnum, line, answer)
-   end)
+  local lnum = api.nvim_win_get_cursor(0)[1]
+  local bufnr = current_buf()
+  local signlines = { {
+    type = "ann",
+    lnum = lnum,
+  } }
+  local mark = M.bookmark_line(lnum, bufnr)
+  vim.ui.input({ prompt = "Edit:", default = mark.a }, function(answer)
+    if answer == nil then return end
+    local line = api.nvim_buf_get_lines(bufnr, lnum - 1, lnum, false)[1]
+    signs:remove(bufnr, lnum)
+    local text = config.keywords[string.sub(answer or "", 1, 2)]
+    if text then
+      signlines[1]["text"] = text
+    end
+    signs:add(bufnr, signlines)
+    updateBookmarks(bufnr, lnum, line, answer)
+  end)
 end
 
 local jump_line = function(prev)
-   local lnum = api.nvim_win_get_cursor(0)[1]
-   local marks = M.bookmark_line()
-   local small, big = {}, {}
-   for k, _ in pairs(marks) do
-      k = tonumber(k)
-      if k < lnum then
-         table.insert(small, k)
-      elseif k > lnum then
-         table.insert(big, k)
-      end
-   end
-   if prev then
-      local tmp = #small > 0 and small or big
-      table.sort(tmp, function(a, b)
-         return a > b
-      end)
-      lnum = tmp[1]
-   else
-      local tmp = #big > 0 and big or small
-      table.sort(tmp)
-      lnum = tmp[1]
-   end
-   if lnum then
-      api.nvim_win_set_cursor(0, { lnum, 0 })
-      local mark = marks[tostring(lnum)]
-      if mark.a then
-         api.nvim_echo({ { "ann: " .. mark.a, "WarningMsg" } }, false, {})
-      else
-      end
-   end
+  local lnum = api.nvim_win_get_cursor(0)[1]
+  local marks = M.bookmark_line()
+  local small, big = {}, {}
+  for k, _ in pairs(marks) do
+    k = tonumber(k)
+    if k < lnum then
+      table.insert(small, k)
+    elseif k > lnum then
+      table.insert(big, k)
+    end
+  end
+  if prev then
+    local tmp = #small > 0 and small or big
+    table.sort(tmp, function(a, b)
+      return a > b
+    end)
+    lnum = tmp[1]
+  else
+    local tmp = #big > 0 and big or small
+    table.sort(tmp)
+    lnum = tmp[1]
+  end
+  if lnum then
+    api.nvim_win_set_cursor(0, { lnum, 0 })
+    local mark = marks[tostring(lnum)]
+    if mark.a then
+      api.nvim_echo({ { "ann: " .. mark.a, "WarningMsg" } }, false, {})
+    end
+  end
 end
 
 M.bookmark_prev = function()
-   jump_line(true)
+  jump_line(true)
 end
 
 M.bookmark_next = function()
-   jump_line(false)
+  jump_line(false)
 end
 
 M.bookmark_list = function()
-   local allmarks = config.cache.data
-   local marklist = {}
-   for k, ma in pairs(allmarks) do
-      if utils.path_exists(k) == false then
-         allmarks[k] = nil
+  local allmarks = config.cache.data
+  local marklist = {}
+  for k, ma in pairs(allmarks) do
+    if utils.path_exists(k) == false then
+      allmarks[k] = nil
+    end
+    for l, v in pairs(ma) do
+      table.insert(marklist, { filename = k, lnum = l, text = v.m .. "|" .. (v.a or "") })
+    end
+  end
+  utils.setqflist(marklist)
+end
+
+local function attach_to_buffer(bufnr)
+  if attached_buffers[bufnr] then return end
+  attached_buffers[bufnr] = true
+
+  api.nvim_buf_attach(bufnr, false, {
+    on_lines = function(_, _, _, firstline, old_lastline, new_lastline, _)
+      local file = uv.fs_realpath(api.nvim_buf_get_name(bufnr))
+      if not file or not config.cache.data[file] then return end
+
+      local delta = new_lastline - old_lastline
+      if delta == 0 then return end
+
+      local old_marks = config.cache.data[file]
+      local new_marks = {}
+
+      for k, v in pairs(old_marks) do
+        local linenum = tonumber(k)
+        if linenum < firstline + 1 then
+          new_marks[tostring(linenum)] = v
+        elseif delta > 0 then
+          new_marks[tostring(linenum + delta)] = v
+        elseif delta < 0 then
+          if linenum + delta >= firstline + 1 then
+            new_marks[tostring(linenum + delta)] = v
+          end
+        end
       end
-      for l, v in pairs(ma) do
-         table.insert(marklist, { filename = k, lnum = l, text = v.m .. "|" .. (v.a or "") })
-      end
-   end
-   utils.setqflist(marklist)
+
+      config.cache.data[file] = new_marks
+      M.refresh(bufnr)
+    end,
+  })
 end
 
 M.refresh = function(bufnr)
-   bufnr = bufnr or current_buf()
-   local file = uv.fs_realpath(api.nvim_buf_get_name(bufnr))
-   if file == nil then
-      return
-   end
-   local marks = config.cache.data[file]
-   local signlines = {}
-   if marks then
-      for k, v in pairs(marks) do
-         local ma = {
-            type = v.a and "ann" or "add",
-            lnum = tonumber(k),
-         }
-         local pref = string.sub(v.a or "", 1, 2)
-         local text = config.keywords[pref]
-         if text then
-            ma["text"] = text
-         end
-         signs:remove(bufnr, ma.lnum)
-         table.insert(signlines, ma)
+  bufnr = bufnr or current_buf()
+  local file = uv.fs_realpath(api.nvim_buf_get_name(bufnr))
+  if file == nil then
+    return
+  end
+  local marks = config.cache.data[file]
+  local signlines = {}
+  if marks then
+    for k, v in pairs(marks) do
+      local ma = {
+        type = v.a and "ann" or "add",
+        lnum = tonumber(k),
+      }
+      local pref = string.sub(v.a or "", 1, 2)
+      local text = config.keywords[pref]
+      if text then
+        ma["text"] = text
       end
-      signs:add(bufnr, signlines)
-   end
+      signs:remove(bufnr, ma.lnum)
+      table.insert(signlines, ma)
+    end
+    signs:add(bufnr, signlines)
+  end
+
+  -- Attach buffer once
+  attach_to_buffer(bufnr)
 end
 
 function M.loadBookmarks()
-   if utils.path_exists(config.save_file) then
-      utils.read_file(config.save_file, function(data)
-         config.cache = vim.json.decode(data)
-         config.marks = data
-      end)
-   end
+  if utils.path_exists(config.save_file) then
+    utils.read_file(config.save_file, function(data)
+      config.cache = vim.json.decode(data)
+      config.marks = data
+    end)
+  end
 end
 
 function M.saveBookmarks()
-   local data = vim.json.encode(config.cache)
-   if config.marks ~= data then
-      utils.write_file(config.save_file, data)
-   end
+  local data = vim.json.encode(config.cache)
+  if config.marks ~= data then
+    utils.write_file(config.save_file, data)
+  end
 end
 
 function M.bookmark_clear_all()
-    config.cache = schema.cache.default
-    M.saveBookmarks()
+  config.cache = schema.cache.default
+  M.saveBookmarks()
 end
 
 return M

--- a/lua/bookmarks/actions.lua
+++ b/lua/bookmarks/actions.lua
@@ -170,6 +170,9 @@ local function attach_to_buffer(bufnr)
   attached_buffers[bufnr] = true
 
   api.nvim_buf_attach(bufnr, false, {
+    on_detach = function()
+      attached_buffers[bufnr] = nil
+    end,
     on_lines = function(_, _, _, firstline, old_lastline, new_lastline, _)
       local file = uv.fs_realpath(api.nvim_buf_get_name(bufnr))
       if not file or not config.cache.data[file] then return end


### PR DESCRIPTION
This update improves the reliability of bookmark tracking in dynamic editing scenarios.

### Changes

- Automatically refresh bookmarks on text changes (`TextChanged`, `TextChangedI`)
- Adjust bookmark line numbers when text is inserted or deleted above them
- Prevent redundant buffer attachments by tracking already-attached buffers
- Improve code formatting and indentation consistency

### Why

Previously, bookmark positions could become inaccurate after inserting lines or using undo operations. This change ensures that bookmarks are updated automatically, maintaining correct positioning across all typical editing actions.

Let me know if any changes are needed. Thanks!